### PR TITLE
Fix: Use encodeURIComponent for tag slugs to support Chinese characters

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,16 +10,8 @@ module.exports = function (eleventyConfig) {
     // 步骤 2: 在所有处理之前，首先调用 .trim() 清除所有前后空格！
     const trimmedStr = str.trim();
 
-    // 步骤 3: 使用清理过的 trimmedStr 进行 slugify
-    let sluggedValue = slugify(trimmedStr, {
-      lowercase: true,
-      remove: /[*+~.()'"!:@]/g,
-    });
-
-    // 步骤 4: 如果结果为空，使用清理过的 trimmedStr 进行编码
-    if (sluggedValue === "") {
-      sluggedValue = encodeURIComponent(trimmedStr).toLowerCase();
-    }
+    // 步骤 3: 直接对清理过的 trimmedStr 进行编码
+    let sluggedValue = encodeURIComponent(trimmedStr);
 
     // （可选）你可以保留这个日志来确认输入和输出
     // console.log(


### PR DESCRIPTION
Previously, Chinese tags resulted in URLs that could not be resolved (Cannot GET /tags/...). This change modifies the `slug` filter in .eleventy.js to use `encodeURIComponent` directly for all tags. This ensures that non-ASCII characters in tags are properly percent-encoded in a standard way, making the generated URLs for tag pages resolvable by the server.